### PR TITLE
Add a warning about changing the USB Dual-Role option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To enable DRD, go into BIOS by shutting down your deck, and holding Volume Up an
 Then, select Setup Utility, then Advanced, then USB Configuration, and finally USB Dual-Role Device. Select DRD
 instead of the existing XHCI and you're set.
 
-## Warning, doing so may prevent you from booting from USB or preventing you from using the ports in Windows
+## Warning, doing so will prevent you from booting from USB and preventing you from using the ports in Windows as long as the setting is set to DRD
 
 ## Build instrutions
 1. Clone the repository to use as an example for making your plugin.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To enable DRD, go into BIOS by shutting down your deck, and holding Volume Up an
 Then, select Setup Utility, then Advanced, then USB Configuration, and finally USB Dual-Role Device. Select DRD
 instead of the existing XHCI and you're set.
 
+## Warning, doing so may prevent you from booting from USB or preventing you from using the ports in Windows
+
 ## Build instrutions
 1. Clone the repository to use as an example for making your plugin.
 2. In your clone of the repository run these commands:


### PR DESCRIPTION
Previously pinged you about it in the Steam Deck discord, I've since encountered multiple cases where people are simply unable to boot Smokeless UMAF or their ports on their docks simply don't work under Windows until they changed from DRD back to XHCI.

Feel free to edit the warning but I don't think omitting to mention something like that is a great idea, I feel like there could be a link to setup SSH/SCP as an alternative.